### PR TITLE
fix: iTerm2のDynamic Profile GUID重複を解消

### DIFF
--- a/private_Library/private_Application Support/iTerm2/DynamicProfiles/Default.json.tmpl
+++ b/private_Library/private_Application Support/iTerm2/DynamicProfiles/Default.json.tmpl
@@ -498,7 +498,7 @@
     },
     "Name" : "Default",
     "Blinking Cursor" : false,
-    "Guid" : "F4755F0C-B9CB-4580-94B9-F79DA20A1433",
+    "Guid" : "BE17FDD9-AD1C-456B-9DEC-FAFED141CF90",
     "Match Background Color" : {
       "Red Component" : 0.99697142839431763,
       "Color Space" : "P3",


### PR DESCRIPTION
## 概要
- iTerm2のDynamic Profileで固定GUIDが既存の非Dynamic Profileと衝突していた問題を修正
- `Default` プロファイルの `Guid` を新しい一意値へ更新

## 変更点
- `private_Library/private_Application Support/iTerm2/DynamicProfiles/Default.json.tmpl`
  - `Guid`: `F4755F0C-B9CB-4580-94B9-F79DA20A1433` -> `BE17FDD9-AD1C-456B-9DEC-FAFED141CF90`

## 確認観点
- iTerm2起動時にGUID衝突ログが出ないこと


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * iTerm2の設定ファイルを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->