### PR TITLE
fix: Codex通知hookのイベント判定を修正

### DIFF
--- a/dot_codex/executable_notify-slack.sh
+++ b/dot_codex/executable_notify-slack.sh
@@ -11,14 +11,14 @@ if [ -z "$payload" ]; then
 fi
 
 event_type="$(printf '%s' "$payload" | jq -r '.type // ""' 2>/dev/null || true)"
-if [ "$event_type" != "approval-requested" ]; then
+if [ "$event_type" != "approval-requested" ] && [ "$event_type" != "agent-turn-complete" ]; then
   exit 0
 fi
 
 message_json="$(printf '%s' "$payload" | jq -c '
   . as $e
   | [
-      "Codex approval requested",
+      (if ($e.type // "") == "approval-requested" then "Codex approval requested" else "Codex turn completed" end),
       ($e.title // empty),
       ($e.message // empty),
       (if ($e.cwd // "") != "" then "wd: \($e.cwd)" else empty end),


### PR DESCRIPTION
## Summary
- notify hook が approval-requested 以外を捨てていたため通知が届かないケースを修正
- agent-turn-complete も受け付けるように変更
- Slack通知タイトルをイベント種別に応じて切替

## Why
- Desktop を含む実環境で notify フックに approval-requested が来ないケースがあり、通知が未送信になっていたため


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Slackメッセージが追加のイベントタイプに対応しました。
  * メッセージヘッダーがイベントの種類に応じて動的に表示されます。
  * セッションIDがメッセージペイロードに含まれるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->