### PR TITLE
docs: chezmoi規約skillをCodexとClaudeへ共通展開

### DIFF
--- a/dot_claude/skills/chezmoi-ryoh827-conventions/SKILL.md.tmpl
+++ b/dot_claude/skills/chezmoi-ryoh827-conventions/SKILL.md.tmpl
@@ -1,0 +1,1 @@
+{{ include "skills/chezmoi-ryoh827-conventions/SKILL.md" }}

--- a/dot_codex/skills/chezmoi-ryoh827-conventions/SKILL.md.tmpl
+++ b/dot_codex/skills/chezmoi-ryoh827-conventions/SKILL.md.tmpl
@@ -1,0 +1,1 @@
+{{ include "skills/chezmoi-ryoh827-conventions/SKILL.md" }}

--- a/dot_codex/skills/chezmoi-ryoh827-conventions/agents/openai.yaml.tmpl
+++ b/dot_codex/skills/chezmoi-ryoh827-conventions/agents/openai.yaml.tmpl
@@ -1,0 +1,1 @@
+{{ include "skills/chezmoi-ryoh827-conventions/agents/openai.yaml" }}

--- a/skills/chezmoi-ryoh827-conventions/SKILL.md
+++ b/skills/chezmoi-ryoh827-conventions/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: chezmoi-ryoh827-conventions
+description: Use this skill when editing ryoh827's chezmoi/dotfiles repo to follow repository-specific path conventions, especially home bin script placement.
+---
+
+# ryoh827 chezmoi Conventions
+
+Use this skill when working in `/Users/ryoh827/.codex/worktrees/*/chezmoi` or the `ryoh827/dotfiles` repository.
+
+## Home bin scripts
+
+- For commands that should be installed under `~/bin`, use `bin/executable_<name>` in the chezmoi source repository.
+- Do not use `dot_bin/` for these scripts in this repository.
+
+## Example
+
+- `~/bin/cmu` -> `bin/executable_cmu`

--- a/skills/chezmoi-ryoh827-conventions/agents/openai.yaml
+++ b/skills/chezmoi-ryoh827-conventions/agents/openai.yaml
@@ -1,0 +1,4 @@
+version: 1
+display_name: Chezmoi Conventions (ryoh827)
+short_description: ryoh827のchezmoiリポジトリ固有の配置ルールを守る
+default_prompt: ryoh827のchezmoi/dotfilesリポジトリの規約に従って変更してください。特に ~/bin 配下のコマンド配置は bin/executable_<name> を使ってください


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Chezmoi Conventions (ryoh827) スキルを新規追加。このスキルにより、dotfilesリポジトリ固有の配置ルール（特にホームディレクトリのbin配下のコマンド配置に関する命名規約）が定義され、適用されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->