### PR TITLE
docs: skill共通展開の手法skillを追加

### DIFF
--- a/dot_claude/skills/chezmoi-shared-skill-fanout/SKILL.md.tmpl
+++ b/dot_claude/skills/chezmoi-shared-skill-fanout/SKILL.md.tmpl
@@ -1,0 +1,1 @@
+{{ include "skills/chezmoi-shared-skill-fanout/SKILL.md" }}

--- a/dot_codex/skills/chezmoi-shared-skill-fanout/SKILL.md.tmpl
+++ b/dot_codex/skills/chezmoi-shared-skill-fanout/SKILL.md.tmpl
@@ -1,0 +1,1 @@
+{{ include "skills/chezmoi-shared-skill-fanout/SKILL.md" }}

--- a/dot_codex/skills/chezmoi-shared-skill-fanout/agents/openai.yaml.tmpl
+++ b/dot_codex/skills/chezmoi-shared-skill-fanout/agents/openai.yaml.tmpl
@@ -1,0 +1,1 @@
+{{ include "skills/chezmoi-shared-skill-fanout/agents/openai.yaml" }}

--- a/skills/chezmoi-shared-skill-fanout/SKILL.md
+++ b/skills/chezmoi-shared-skill-fanout/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: chezmoi-shared-skill-fanout
+description: Use this skill when adding or updating a skill in ryoh827's dotfiles so the same source is deployed to both Codex and Claude via chezmoi includes.
+---
+
+# Chezmoi Shared Skill Fanout
+
+Use this skill when you need one skill definition to be available in both Codex and Claude in the `ryoh827/dotfiles` repository.
+
+## Source of truth
+
+- Put the canonical skill files under `skills/<skill-name>/`.
+- Edit only the files in `skills/<skill-name>/` when updating content.
+
+## Codex deployment
+
+- Add `dot_codex/skills/<skill-name>/SKILL.md.tmpl` with `{{ include "skills/<skill-name>/SKILL.md" }}`.
+- If the skill has Codex UI metadata, store the canonical file at `skills/<skill-name>/agents/openai.yaml`.
+- Add `dot_codex/skills/<skill-name>/agents/openai.yaml.tmpl` with `{{ include "skills/<skill-name>/agents/openai.yaml" }}`.
+
+## Claude deployment
+
+- Add `dot_claude/skills/<skill-name>/SKILL.md.tmpl` with `{{ include "skills/<skill-name>/SKILL.md" }}`.
+
+## Checks
+
+- Verify both wrapper files point to the same `skills/<skill-name>/SKILL.md`.
+- Keep wrappers as include-only files, like `dot_codex/AGENTS.md.tmpl` and `dot_config/claude/CLAUDE.md.tmpl`.

--- a/skills/chezmoi-shared-skill-fanout/agents/openai.yaml
+++ b/skills/chezmoi-shared-skill-fanout/agents/openai.yaml
@@ -1,0 +1,4 @@
+version: 1
+display_name: Chezmoi Shared Skill Fanout
+short_description: 1つのskill sourceをCodex/Claudeへchezmoi includeで展開する
+default_prompt: ryoh827のdotfilesで新しいskillを追加します。skills配下をsource of truthにして、dot_codexとdot_claudeへincludeで展開する構成で作成してください


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Chezmoi Shared Skill Fanout機能を導入しました。単一のスキル定義をCodexとClaudeで共有できるようになります。中央で管理されたスキルは、各システムに自動的に展開されます。

* **ドキュメンテーション**
  * スキル共有のプロセス、デプロイメント手順、検証チェック、およびOpenAIエージェント設定を説明した新しいドキュメントを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->