### PR TITLE
feat: plan-reviewとplan-goの共有スキルを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,11 @@
 - コミットメッセージは日本語で記述する (Write commit messages in Japanese)
 - feat:, fix:, docs:, refactor: などのプレフィックスを付ける (Use prefixes like feat:, fix:, docs:, refactor:)
 - Example: "feat: ユーザー認証機能を追加"
+
+## Plan Workflow Defaults
+- プランモードで `<proposed_plan>` を提示した直後に通常モードへ移った場合、ユーザーが拒否しない限り次を既定で実行する
+- Save the proposed plan to a file by default after leaving Plan mode unless the user opts out
+- 保存先はユーザー指定があれば最優先、指定がなければ `docs/plans/<YYYY-MM-DD>_<slug>.md` を使う
+- `docs/plans/` は合意済みプランの保存先として扱う
+- 保存後は `plan-review` ワークフローをそのファイルに対して実行する
+- `plan-go` は明示依頼があるときだけ実行する

--- a/dot_claude/skills/plan-go/SKILL.md.tmpl
+++ b/dot_claude/skills/plan-go/SKILL.md.tmpl
@@ -1,0 +1,1 @@
+{{ include "skills/plan-go/SKILL.md" }}

--- a/dot_claude/skills/plan-review/SKILL.md.tmpl
+++ b/dot_claude/skills/plan-review/SKILL.md.tmpl
@@ -1,0 +1,1 @@
+{{ include "skills/plan-review/SKILL.md" }}

--- a/dot_codex/skills/plan-go/SKILL.md.tmpl
+++ b/dot_codex/skills/plan-go/SKILL.md.tmpl
@@ -1,0 +1,1 @@
+{{ include "skills/plan-go/SKILL.md" }}

--- a/dot_codex/skills/plan-go/agents/openai.yaml.tmpl
+++ b/dot_codex/skills/plan-go/agents/openai.yaml.tmpl
@@ -1,0 +1,1 @@
+{{ include "skills/plan-go/agents/openai.yaml" }}

--- a/dot_codex/skills/plan-review/SKILL.md.tmpl
+++ b/dot_codex/skills/plan-review/SKILL.md.tmpl
@@ -1,0 +1,1 @@
+{{ include "skills/plan-review/SKILL.md" }}

--- a/dot_codex/skills/plan-review/agents/openai.yaml.tmpl
+++ b/dot_codex/skills/plan-review/agents/openai.yaml.tmpl
@@ -1,0 +1,1 @@
+{{ include "skills/plan-review/agents/openai.yaml" }}

--- a/skills/plan-go/SKILL.md
+++ b/skills/plan-go/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: plan-go
+description: Execute an approved implementation plan file step by step, enforce unresolved-marker gate checks (XXX:/TODO:/AI-ASK:), run verification commands in defined priority, and remove the plan file after successful completion.
+---
+
+# Plan Go
+
+Use this skill to execute an approved plan document step by step.
+
+## Workflow
+
+1. Read the specified `filename` and understand the full plan.
+2. Before any implementation, scan for unresolved markers:
+   - `XXX:`
+   - `TODO:`
+   - `AI-ASK:`
+3. If any unresolved markers remain, stop and ask the user to confirm how to proceed.
+4. Determine execution order:
+   - Follow explicit TDD order if the plan defines it.
+   - Otherwise follow the plan structure from top to bottom.
+5. Implement each step:
+   - Briefly state what you will do before starting each step.
+   - If tests are present, apply Red, then Green, then Refactor.
+   - Keep changes minimal and within the plan scope.
+   - After each step, run verification with this priority:
+     1. Use the plan-defined verification command for that step.
+     2. Use `bun run typecheck && bun test`.
+     3. Use project-standard verification commands if bun commands do not apply.
+6. After all steps, run the final verification defined in the plan.
+7. After successful completion, delete the plan file.
+
+## Constraints
+
+- Do not do anything outside the plan.
+- Do not add out-of-scope improvements or refactors.
+- If implementation contradicts the plan, stop and confirm with the user.
+- Do not leave existing tests broken. Identify and fix failures caused by your changes.

--- a/skills/plan-go/agents/openai.yaml
+++ b/skills/plan-go/agents/openai.yaml
@@ -1,0 +1,4 @@
+version: 1
+display_name: Plan Go
+short_description: 承認済みプランを順番に実装して検証まで実行する
+default_prompt: 指定したplanファイルに従って順番に実装し、各ステップで検証して最後にplanファイルを削除してください

--- a/skills/plan-go/agents/openai.yaml
+++ b/skills/plan-go/agents/openai.yaml
@@ -1,4 +1,4 @@
 version: 1
 display_name: Plan Go
 short_description: 承認済みプランを順番に実装して検証まで実行する
-default_prompt: 指定したplanファイルに従って順番に実装し、各ステップで検証して最後にplanファイルを削除してください
+default_prompt: 指定したplanファイルを読み、未解決マーカー（XXX:/TODO:/AI-ASK:）が残っていれば実装前に停止して確認を取り、問題なければSKILL.mdの安全条件と検証条件に従って順番に実装し、成功時のみplanファイルを削除してください

--- a/skills/plan-review/SKILL.md
+++ b/skills/plan-review/SKILL.md
@@ -26,7 +26,7 @@ Use this skill when the user wants plan-only refinement.
 4. Insert each issue immediately after the relevant section as:
    - `AI-ASK: {question}`
 5. Provide a summary of edits and added questions.
-6. If there are no `XXX:` comments and no added questions, respond exactly:
+6. If there are no unresolved markers (`XXX:`, `TODO:`, `AI-ASK:`), respond exactly:
    - `No unclear points in the plan. Ready for implementation.`
 
 ## Constraints

--- a/skills/plan-review/SKILL.md
+++ b/skills/plan-review/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: plan-review
+description: Review and improve a plan document by applying inline feedback markers (XXX:), adding targeted clarification questions as AI-ASK:, and producing a concise change summary. Use when a user asks to refine planning docs before implementation without writing code.
+---
+
+# Plan Review
+
+Use this skill when the user wants plan-only refinement.
+
+## Workflow
+
+1. Read the specified `filename` and understand the full plan.
+2. Apply all `XXX:` feedback in the file:
+   - Revise design when comments raise concerns or objections.
+   - Evaluate alternatives, then adopt or reject with rationale reflected in the plan.
+   - Incorporate added requirements or constraints.
+   - Add missing perspectives when noted.
+   - Remove resolved `XXX:` comments.
+   - If a comment cannot be resolved now, replace it with `TODO:`.
+3. Perform critical analysis from these perspectives:
+   - ambiguous descriptions
+   - overlooked considerations (edge cases, error handling, consistency)
+   - implicit assumptions
+   - unjustified design choices where alternatives exist
+   - unclear in-scope and out-of-scope boundaries
+4. Insert each issue immediately after the relevant section as:
+   - `AI-ASK: {question}`
+5. Provide a summary of edits and added questions.
+6. If there are no `XXX:` comments and no added questions, respond exactly:
+   - `No unclear points in the plan. Ready for implementation.`
+
+## Constraints
+
+- Never start implementation.
+- Update only the plan file.
+- Do not edit or create code files.
+- Preserve existing plan format and structure.

--- a/skills/plan-review/agents/openai.yaml
+++ b/skills/plan-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+version: 1
+display_name: Plan Review
+short_description: プラン内のXXX反映とAI-ASK追記で実装前の品質を高める
+default_prompt: planファイルをレビューし、XXXコメントを反映してAI-ASKを追記したうえで変更点を要約してください


### PR DESCRIPTION
## 概要
- plan-review と plan-go の共有スキルを追加
- skills 配下を正本にして dot_codex / dot_claude へ include 展開
- Plan Mode 後の既定運用（保存先 docs/plans、保存後 plan-review 実行）を AGENTS.md に追加

## 変更ファイル
- AGENTS.md
- skills/plan-review/SKILL.md
- skills/plan-review/agents/openai.yaml
- skills/plan-go/SKILL.md
- skills/plan-go/agents/openai.yaml
- dot_codex/skills/plan-review/SKILL.md.tmpl
- dot_codex/skills/plan-review/agents/openai.yaml.tmpl
- dot_codex/skills/plan-go/SKILL.md.tmpl
- dot_codex/skills/plan-go/agents/openai.yaml.tmpl
- dot_claude/skills/plan-review/SKILL.md.tmpl
- dot_claude/skills/plan-go/SKILL.md.tmpl

## 確認
- 追加ファイルの存在確認
- include 参照確認
- SKILL.md frontmatter と openai.yaml 必須キー確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリース ノート

* **新機能**
  * Plan Go スキル：承認済みプランを順序立てて実装し、各ステップで検証するワークフローを追加
  * Plan Review スキル：プランドキュメントを詳細に精査し、不明点を整理して実装準備を整える機能を追加
  * OpenAI エージェント対応：両スキルで AI アシスタントを活用可能

* **ドキュメント**
  * プランワークフローのデフォルト動作仕様（保存先、実行順序、レビュー／実行の既定動作など）を追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->