### PR TITLE
chore: binのskill用ラッパースクリプトを削除

### DIFF
--- a/bin/executable_codex-pr-review-fetch
+++ b/bin/executable_codex-pr-review-fetch
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-exec "${HOME}/.codex/codex-pr-review-fetch.sh" "$@"

--- a/bin/executable_codex-pr-review-fix
+++ b/bin/executable_codex-pr-review-fix
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-exec "${HOME}/.codex/codex-pr-review-fix.sh" "$@"


### PR DESCRIPTION
## 概要
- bin 配下に残っていた skill 用ラッパースクリプトを削除
- executable_cgb と executable_cmu は維持

## 変更ファイル
- bin/executable_codex-pr-review-fetch (削除)
- bin/executable_codex-pr-review-fix (削除)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 2つの実行可能ラッパースクリプトを削除し、プロジェクト構成を簡潔化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->