### PR TITLE
docs: コミット署名必須ルールを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@
 ## Git Commit Rules
 - コミットメッセージは日本語で記述する (Write commit messages in Japanese)
 - feat:, fix:, docs:, refactor: などのプレフィックスを付ける (Use prefixes like feat:, fix:, docs:, refactor:)
+- コミット時は署名を必須にする (Require signed commits)
 - Example: "feat: ユーザー認証機能を追加"
 
 ## Plan Workflow Defaults


### PR DESCRIPTION
## 概要
- AGENTS.md の Git Commit Rules に『コミット時は署名を必須にする』ルールを追加

## 変更内容
- AGENTS.md に 1 行追記

## 確認
- ドキュメント変更のみ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Git コミット規則に署名済みコミットの要件が追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->