### PR TITLE
fix: Ghosttyテーマ名を正しい形式に修正

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -1,1 +1,1 @@
-theme = catppuccin-latte
+theme = Catppuccin Latte


### PR DESCRIPTION
## Summary
- Ghosttyのテーマ名を `catppuccin-latte` → `Catppuccin Latte` に修正
- Ghosttyのビルトインテーマはスペース区切り・大文字始まりの形式が正しい

## Test plan
- [ ] Ghostty起動時にテーマが正しく適用されることを確認

このPRはClaude Codeを活用して作成しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## チョア (Chores)

* Ghostty設定ファイルのカラーテーマを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->