### PR TITLE
feat: pr-createスキルを追加

### DIFF
--- a/dot_claude/skills/pr-create/SKILL.md.tmpl
+++ b/dot_claude/skills/pr-create/SKILL.md.tmpl
@@ -1,0 +1,1 @@
+{{ include "skills/pr-create/SKILL.md" }}

--- a/dot_codex/skills/pr-create/SKILL.md.tmpl
+++ b/dot_codex/skills/pr-create/SKILL.md.tmpl
@@ -1,0 +1,1 @@
+{{ include "skills/pr-create/SKILL.md" }}

--- a/dot_codex/skills/pr-create/agents/openai.yaml.tmpl
+++ b/dot_codex/skills/pr-create/agents/openai.yaml.tmpl
@@ -1,0 +1,1 @@
+{{ include "skills/pr-create/agents/openai.yaml" }}

--- a/skills/pr-create/SKILL.md
+++ b/skills/pr-create/SKILL.md
@@ -19,7 +19,7 @@ description: Use this skill when you want to push the current branch and create 
 
 ### 1. ベースブランチの特定
 
-```
+```bash
 git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'
 ```
 
@@ -29,14 +29,14 @@ git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'
 
 以下を実行して全コミットの内容を把握する:
 
-```
+```bash
 git log <base>..HEAD --oneline
 git diff <base>...HEAD --stat
 ```
 
 ### 3. Push
 
-```
+```bash
 git push -u origin HEAD
 ```
 
@@ -57,8 +57,8 @@ git push -u origin HEAD
 
 PRを作成する:
 
-```
-gh pr create --title "<title>" --body "<body>"
+```bash
+gh pr create --base "<base>" --title "<title>" --body "<body>"
 ```
 
 ### 5. 結果

--- a/skills/pr-create/SKILL.md
+++ b/skills/pr-create/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: pr-create
+description: Use this skill when you want to push the current branch and create a GitHub PR in one run without per-step confirmations.
+---
+
+# PR Create
+
+現在のブランチをリモートにpushし、全コミットを分析してGitHub PRを作成するスキル。
+各ステップ間で承認を求めず一括実行する。
+
+## 前提チェック
+
+以下を満たさない場合はエラーで停止する:
+
+- 現在のブランチが `main` または `master` でないこと
+- ワーキングツリーがクリーンであること（未コミットの変更がないこと）
+
+## ワークフロー
+
+### 1. ベースブランチの特定
+
+```
+git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'
+```
+
+取得できない場合は `main` をフォールバックとする。
+
+### 2. コミット分析
+
+以下を実行して全コミットの内容を把握する:
+
+```
+git log <base>..HEAD --oneline
+git diff <base>...HEAD --stat
+```
+
+### 3. Push
+
+```
+git push -u origin HEAD
+```
+
+### 4. PR作成
+
+全コミットの内容を元に以下を作成する:
+
+- **タイトル**: 70文字以内、変更の要約
+- **本文**: 以下のフォーマット
+
+```markdown
+## Summary
+<1-3行の箇条書き>
+
+## Test plan
+<テスト手順の箇条書き>
+```
+
+PRを作成する:
+
+```
+gh pr create --title "<title>" --body "<body>"
+```
+
+### 5. 結果
+
+作成されたPRのURLを返却する。
+
+## 制約
+
+- ステップ間で承認を求めない
+- PRタイトルは70文字以内に収める
+- コミットメッセージの言語に合わせてPRタイトル・本文の言語を決定する

--- a/skills/pr-create/agents/openai.yaml
+++ b/skills/pr-create/agents/openai.yaml
@@ -1,0 +1,4 @@
+version: 1
+display_name: PR Create
+short_description: 現在のブランチをpushしてGitHub PRを作成する
+default_prompt: 現在のブランチをリモートにpushし、全コミットを分析してPRを作成してください


### PR DESCRIPTION
## Summary
- pushからPR作成までを承認なしで一括実行する `pr-create` スキルを追加
- `chezmoi-shared-skill-fanout` パターンに従い、canonical source + テンプレートで構成
- `dot_claude` / `dot_codex` 両方へのデプロイに対応

## Test plan
- [ ] `chezmoi apply --dry-run` でテンプレート展開エラーがないこと
- [ ] `chezmoi diff` で意図した差分のみ出力されること
- [ ] スキル実行時にpush→PR作成が承認なしで完了すること

このPRはClaude Codeを活用して作成しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 「PR作成」スキルを追加：現在のブランチをリモートへプッシュし、コミットを解析してGitHubのプルリクエストを自動作成します（メイン/マスター以外、作業ツリーがクリーンであることが前提）。
  * エージェント設定を追加し、PR作成の自動化ワークフローをサポートします。
* **ドキュメント**
  * スキルの利用手順、前提条件、出力フォーマット（PRタイトル/本文制約等）を記載したドキュメントを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->