### PR TITLE
feat: Ghosttyテーマをダーク系(Catppuccin Mocha)に変更

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -1,1 +1,1 @@
-theme = Catppuccin Latte
+theme = Catppuccin Mocha


### PR DESCRIPTION
## Summary
- GhosttyのテーマをCatppuccin Latte（ライト）からCatppuccin Mocha（ダーク）に変更

## Test plan
- [ ] `chezmoi apply` 後にGhosttyを再起動し、ダークテーマが適用されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * デフォルトテーマを「Catppuccin Latte」から「Catppuccin Mocha」に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->