### PR TITLE
Add HackGen Console NF font and font-size to Ghostty config

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -1,1 +1,3 @@
 theme = Catppuccin Mocha
+font-family = HackGen Console NF
+font-size = 14


### PR DESCRIPTION
## Summary
- Ghostty の日本語フォントに HackGen Console NF を設定
- font-size をデフォルト(13pt)から 14pt に変更

## Test plan
- Ghostty を再起動してフォントが HackGen Console NF に変わっていることを確認
- 日本語表示が正しくレンダリングされることを確認
- フォントサイズが 14pt になっていることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* ターミナル設定ファイルにカスタムフォント（HackGen Console NF）とフォントサイズ（14）の設定を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->