### PR TITLE
Configure Ghostty with HackGen Console NF and font-size 15

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -1,3 +1,3 @@
 theme = Catppuccin Mocha
 font-family = HackGen Console NF
-font-size = 14
+font-size = 15


### PR DESCRIPTION
## Summary
- Add HackGen Console NF as the font family for Ghostty
- Set font-size to 15 for improved readability

## Test plan
- [ ] Verify `chezmoi apply` applies the config correctly
- [ ] Confirm Ghostty reflects the new font and size

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ターミナルの標準フォントサイズを 15 に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->