### PR TITLE
feat: .claude/CLAUDE.md を AGENTS.md と同内容で配信

### DIFF
--- a/dot_claude/CLAUDE.md.tmpl
+++ b/dot_claude/CLAUDE.md.tmpl
@@ -1,0 +1,1 @@
+{{ include "AGENTS.md" }}


### PR DESCRIPTION
## Summary
- `dot_claude/CLAUDE.md.tmpl` を追加し、chezmoi の `{{ include "AGENTS.md" }}` で `~/.claude/CLAUDE.md` にルートの `AGENTS.md` をそのまま配信する
- 既存の `dot_codex/AGENTS.md.tmpl` と同じパターンで対称化し、Codex / Claude Code の両方に同じグローバル指示が反映される

## Test plan
- [x] `chezmoi diff ~/.claude/CLAUDE.md` で期待差分を確認
- [x] `chezmoi apply ~/.claude/CLAUDE.md` で `~/.claude/CLAUDE.md` が `AGENTS.md` と同内容で生成されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメンテーション**
  * テンプレートファイルに別ファイルのコンテンツを含めるための指示を追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoh827/dotfiles/pull/37)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->