### PR TITLE
feat: nvim-treesitter を main ブランチ API で導入

### DIFF
--- a/dot_config/nvim/lua/plugins/spec.lua
+++ b/dot_config/nvim/lua/plugins/spec.lua
@@ -83,6 +83,10 @@ return {
         'ruby',
       })
 
+      vim.treesitter.language.register('vimdoc', 'help')
+      vim.treesitter.language.register('bash', { 'sh', 'zsh' })
+      vim.treesitter.language.register('tsx', 'typescriptreact')
+
       vim.api.nvim_create_autocmd('FileType', {
         pattern = {
           'lua',

--- a/dot_config/nvim/lua/plugins/spec.lua
+++ b/dot_config/nvim/lua/plugins/spec.lua
@@ -58,6 +58,60 @@ return {
   {'github/copilot.vim'},
   {'tpope/vim-endwise'},
   {
+    'nvim-treesitter/nvim-treesitter',
+    branch = 'main',
+    lazy = false,
+    build = ':TSUpdate',
+    config = function()
+      require('nvim-treesitter').install({
+        'lua',
+        'vim',
+        'vimdoc',
+        'bash',
+        'json',
+        'yaml',
+        'toml',
+        'markdown',
+        'markdown_inline',
+        'html',
+        'css',
+        'javascript',
+        'typescript',
+        'tsx',
+        'go',
+        'python',
+        'ruby',
+      })
+
+      vim.api.nvim_create_autocmd('FileType', {
+        pattern = {
+          'lua',
+          'vim',
+          'help',
+          'sh',
+          'bash',
+          'zsh',
+          'json',
+          'yaml',
+          'toml',
+          'markdown',
+          'html',
+          'css',
+          'javascript',
+          'typescript',
+          'typescriptreact',
+          'go',
+          'python',
+          'ruby',
+        },
+        callback = function()
+          pcall(vim.treesitter.start)
+          vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+        end,
+      })
+    end,
+  },
+  {
     'Wansmer/treesj',
     dependencies = { 'nvim-treesitter/nvim-treesitter' },
     config = function()


### PR DESCRIPTION
## Summary
- `nvim-treesitter` を新 `main` ブランチで導入。`configs.setup` 廃止に伴い `require('nvim-treesitter').install({...})` + FileType autocmd で `vim.treesitter.start()` と `indentexpr` を有効化。
- 主要言語のパーサ（lua/vim/bash/json/yaml/toml/markdown/html/css/js/ts/tsx/go/python/ruby）を事前 install。
- 動作には別途 `tree-sitter-cli` (brew) が必要。Brewfile への追記は別 PR で検討。

## Test plan
- [ ] `chezmoi apply` 後に `nvim` を起動して lazy が `nvim-treesitter` (branch=main) を取得することを確認
- [ ] `:checkhealth nvim-treesitter` でパーサが OK 表示になることを確認
- [ ] 各言語のファイル（例: lua, ts, go, py, rb）を開いてシンタックスハイライトが効くことを確認
- [ ] 改行・ペースト時のインデントが妥当に効くことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **設定**
  * Treesitterプラグインを追加し、構文解析と自動インデント機能を強化
  * 複数のプログラミング言語に対応した言語パックを自動インストール

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoh827/dotfiles/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->