### PR TITLE
feat: mise で .terraform-version を読み込めるよう設定

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -7,7 +7,7 @@ ghc = "9.12.2"
 node = "24.1.0"
 
 [settings]
-idiomatic_version_file_enable_tools = ["ruby", "node", "pnpm"]
+idiomatic_version_file_enable_tools = ["ruby", "node", "pnpm", "terraform"]
 
 [settings.python]
 venv_stdlib = true


### PR DESCRIPTION
## Summary
- `idiomatic_version_file_enable_tools` に `terraform` を追加
- `.terraform-version` を持つディレクトリで mise が該当バージョンの terraform を自動選択するようになる

## Test plan
- [ ] `chezmoi apply` で `~/.config/mise/config.toml` に反映される
- [ ] `.terraform-version` を含むディレクトリで `mise current terraform` が当該バージョンを表示する
- [ ] `mise install terraform` 後、`terraform -version` で `.terraform-version` の値と一致する