### PR TITLE
feat: mise グローバルツールに terraform を追加

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -5,6 +5,7 @@ ruby = ["3.5-dev", "3.4.4"]
 rust = "stable"
 ghc = "9.12.2"
 node = "24.1.0"
+terraform = "latest"
 
 [settings]
 idiomatic_version_file_enable_tools = ["ruby", "node", "pnpm", "terraform"]


### PR DESCRIPTION
## Summary
- `[tools]` に `terraform = "latest"` を追加
- `mise use -g terraform@latest` 相当を chezmoi に永続化し、新環境でも `chezmoi apply` 直後から terraform を利用できる
- `.terraform-version` がある作業ディレクトリでは引き続きそちらが優先される

## Test plan
- [ ] `chezmoi apply` 後 `~/.config/mise/config.toml` の `[tools]` に `terraform = "latest"` がある
- [ ] `mise current terraform` が最新版を返す
- [ ] `.terraform-version` を含むディレクトリ内では `mise current terraform` がその値になる