### PR TITLE
fix: telescope.nvim を master 追従に変更 (treesitter main 対応)

### DIFF
--- a/dot_config/nvim/lua/plugins/telescope.lua
+++ b/dot_config/nvim/lua/plugins/telescope.lua
@@ -1,6 +1,6 @@
 return {
   {
-    'nvim-telescope/telescope.nvim', tag = '0.1.8',
+    'nvim-telescope/telescope.nvim', branch = 'master',
     dependencies = { 'nvim-lua/plenary.nvim' },
     config = function()
       require('telescope').setup({


### PR DESCRIPTION
## Summary
- `tag = '0.1.8'` のままだと、nvim-treesitter main で廃止された `nvim-treesitter.parsers.ft_to_lang` を telescope のプレビュアが呼んでしまい、`attempt to call field 'ft_to_lang' (a nil value)` で落ちる。
- master では当該呼び出しが削除済みだが、まだタグ付きリリース（0.1.8 が最新）に含まれていないため `branch = 'master'` で追従する。

## Test plan
- [ ] `chezmoi apply` → `nvim` 起動 → `:Lazy update telescope.nvim` で master に更新されることを確認
- [ ] `:Telescope find_files` でファイル選択後、プレビューが表示されエラーが出ないことを確認
- [ ] 各種言語ファイル（lua, ts, go, py, rb など）のプレビューでハイライトが効くことを確認