### PR TITLE
feat: nvim-autopairs と診断エラー詳細表示のキーマップを追加

### DIFF
--- a/dot_config/nvim/keymaps.lua
+++ b/dot_config/nvim/keymaps.lua
@@ -42,3 +42,19 @@ vim.api.nvim_set_keymap('n', 'K', '<cmd>lua vim.lsp.buf.hover()<CR>', { noremap 
 vim.api.nvim_set_keymap('n', 'gi', '<cmd>lua vim.lsp.buf.implementation()<CR>', { noremap = true, silent = true, desc = "Implementation" })
 vim.api.nvim_set_keymap('n', '<C-k>', '<cmd>lua vim.lsp.buf.signature_help()<CR>', { noremap = true, silent = true, desc = "Signature Help" })
 
+vim.diagnostic.config({
+  virtual_text = true,
+  severity_sort = true,
+  float = {
+    border = "rounded",
+    source = true,
+    header = "",
+    prefix = "",
+  },
+})
+
+vim.keymap.set('n', 'gl', function() vim.diagnostic.open_float(nil, { focus = false }) end, { noremap = true, silent = true, desc = "Show line diagnostics" })
+vim.keymap.set('n', '[d', function() vim.diagnostic.jump({ count = -1, float = true }) end, { noremap = true, silent = true, desc = "Previous diagnostic" })
+vim.keymap.set('n', ']d', function() vim.diagnostic.jump({ count = 1, float = true }) end, { noremap = true, silent = true, desc = "Next diagnostic" })
+vim.keymap.set('n', '<leader>dq', vim.diagnostic.setloclist, { noremap = true, silent = true, desc = "Diagnostics to loclist" })
+

--- a/dot_config/nvim/lua/plugins/spec.lua
+++ b/dot_config/nvim/lua/plugins/spec.lua
@@ -12,6 +12,13 @@ return {
     end
   },
   {
+    "windwp/nvim-autopairs",
+    event = "InsertEnter",
+    config = function()
+      require("nvim-autopairs").setup({})
+    end,
+  },
+  {
     "glidenote/memolist.vim",
     config = function()
       vim.g.memolist_path = home_dir .. "/memo"


### PR DESCRIPTION
## Summary
- `dot_config/nvim/lua/plugins/spec.lua` に `windwp/nvim-autopairs` を追加（`InsertEnter` 遅延ロード、デフォルト設定）
- `keymaps.lua` に LSP 診断（エラー/警告）の詳細表示キーマップを追加
  - `gl` でカーソル行の診断をフロートウィンドウ表示
  - `[d` / `]d` で前後の診断にジャンプ
  - `<leader>dq` で診断一覧を loclist に格納
  - `vim.diagnostic.config` で virtual_text 有効化、フロートに rounded border と source 表示

## Test plan
- [ ] `chezmoi apply` 後に Neovim を起動し、lazy.nvim が nvim-autopairs を自動インストールすること
- [ ] 挿入モードで \`(\`, \`[\`, \`{\`, \`'\`, \`"\` を入力したときに対応する閉じ文字が自動補完されること
- [ ] LSP がアタッチされたバッファでエラー行に移動し \`gl\` でフロート表示されること
- [ ] \`[d\` / \`]d\` で前後の診断箇所にジャンプできること
- [ ] \`<leader>dq\` で loclist に診断一覧が出ること