### PR TITLE
feat: 診断エラー詳細表示のキーマップを追加

### DIFF
--- a/dot_config/nvim/keymaps.lua
+++ b/dot_config/nvim/keymaps.lua
@@ -42,3 +42,19 @@ vim.api.nvim_set_keymap('n', 'K', '<cmd>lua vim.lsp.buf.hover()<CR>', { noremap 
 vim.api.nvim_set_keymap('n', 'gi', '<cmd>lua vim.lsp.buf.implementation()<CR>', { noremap = true, silent = true, desc = "Implementation" })
 vim.api.nvim_set_keymap('n', '<C-k>', '<cmd>lua vim.lsp.buf.signature_help()<CR>', { noremap = true, silent = true, desc = "Signature Help" })
 
+vim.diagnostic.config({
+  virtual_text = true,
+  severity_sort = true,
+  float = {
+    border = "rounded",
+    source = true,
+    header = "",
+    prefix = "",
+  },
+})
+
+vim.keymap.set('n', 'gl', function() vim.diagnostic.open_float(nil, { focus = false }) end, { noremap = true, silent = true, desc = "Show line diagnostics" })
+vim.keymap.set('n', '[d', function() vim.diagnostic.jump({ count = -1, float = true }) end, { noremap = true, silent = true, desc = "Previous diagnostic" })
+vim.keymap.set('n', ']d', function() vim.diagnostic.jump({ count = 1, float = true }) end, { noremap = true, silent = true, desc = "Next diagnostic" })
+vim.keymap.set('n', '<leader>dq', vim.diagnostic.setloclist, { noremap = true, silent = true, desc = "Diagnostics to loclist" })
+


### PR DESCRIPTION
## Summary
- `gl` でカーソル行の診断（LSP エラー/警告）をフロートウィンドウ表示
- `[d` / `]d` で前後の診断にジャンプ
- `<leader>dq` で診断一覧を loclist に格納
- `vim.diagnostic.config` で virtual_text 有効化、フロートに rounded border と source 表示

## Test plan
- [ ] LSP がアタッチされたバッファでエラー行に移動し `gl` でフロート表示されること
- [ ] `[d` / `]d` で前後の診断箇所にジャンプできること
- [ ] `<leader>dq` で loclist に診断一覧が出ること