### PR TITLE
feat: 非対話シェルで mise shims を PATH に追加する .zshenv を追加

### DIFF
--- a/dot_zshenv
+++ b/dot_zshenv
@@ -1,0 +1,1 @@
+export PATH="$HOME/.local/share/mise/shims:$PATH"


### PR DESCRIPTION
## Summary
- `~/.zshrc` で `mise activate zsh` していたが、zsh は対話シェルでしか `.zshrc` を読まない
- Claude Code などが spawn する非対話シェル (`zsh -c` / `sh -c` / `env -i` 経由) では mise の PATH が一切入らず、mise でインストールしたツールが「動く時と動かない時がある」状態だった
- `dot_zshenv` を追加し、`$HOME/.local/share/mise/shims` を PATH 先頭に置くことで全シェル種別から解決できるようにする
- 起動コストの大きい `mise activate` ではなく shims のみを通す軽量な方針

## Test plan
- [x] `env -i HOME=$HOME zsh -c 'echo $PATH'` で `mise/shims` が含まれる
- [x] `env -i HOME=$HOME PATH=/usr/bin:/bin zsh -c 'node --version'` が `v24.1.0` を返す
- [x] `env -i HOME=$HOME PATH=/usr/bin:/bin zsh -c 'deno --version'` が `deno 2.1.6` を返す
- [ ] 新しい Claude Code セッションを起動して mise ツールが安定して見えることを確認

このPRはClaude Codeを活用して作成しました