### PR TITLE
feat: vim から相対パス・GitHub リンクをコピーできるキーマップを追加

### DIFF
--- a/dot_config/nvim/keymaps.lua
+++ b/dot_config/nvim/keymaps.lua
@@ -53,6 +53,27 @@ vim.diagnostic.config({
   },
 })
 
+vim.keymap.set('n', '<leader>yp', function()
+  local abs = vim.fn.expand('%:p')
+  if abs == '' then
+    vim.notify('No file in buffer', vim.log.levels.WARN)
+    return
+  end
+  local root = vim.fn.systemlist({ 'git', '-C', vim.fn.expand('%:p:h'), 'rev-parse', '--show-toplevel' })[1]
+  local path
+  if vim.v.shell_error == 0 and root and root ~= '' then
+    path = abs:sub(#root + 2)
+  else
+    path = vim.fn.fnamemodify(abs, ':.')
+  end
+  vim.fn.setreg('+', path)
+  vim.notify('Yanked: ' .. path)
+end, { desc = 'Yank relative path (repo root)' })
+
+vim.keymap.set({ 'n', 'x' }, '<leader>yg', '<cmd>GitLink<cr>', { desc = 'Yank GitHub link (HEAD commit)' })
+vim.keymap.set({ 'n', 'x' }, '<leader>yG', '<cmd>GitLink default_branch<cr>', { desc = 'Yank GitHub link (default branch)' })
+vim.keymap.set({ 'n', 'x' }, '<leader>yo', '<cmd>GitLink!<cr>', { desc = 'Open GitHub link in browser' })
+
 vim.keymap.set('n', 'gl', function() vim.diagnostic.open_float(nil, { focus = false }) end, { noremap = true, silent = true, desc = "Show line diagnostics" })
 vim.keymap.set('n', '[d', function() vim.diagnostic.jump({ count = -1, float = true }) end, { noremap = true, silent = true, desc = "Previous diagnostic" })
 vim.keymap.set('n', ']d', function() vim.diagnostic.jump({ count = 1, float = true }) end, { noremap = true, silent = true, desc = "Next diagnostic" })

--- a/dot_config/nvim/lua/plugins/spec.lua
+++ b/dot_config/nvim/lua/plugins/spec.lua
@@ -133,6 +133,11 @@ return {
   },
   {'monaqa/dial.nvim'},
   {
+    "linrongbin16/gitlinker.nvim",
+    cmd = "GitLink",
+    opts = {},
+  },
+  {
     'lewis6991/gitsigns.nvim',
     config = function()
       require('gitsigns').setup()


### PR DESCRIPTION
## Summary
- `linrongbin16/gitlinker.nvim` を導入し、HEAD コミット / default branch どちらの GitHub リンクも生成可能に
- `<leader>yp` でリポジトリルートからの相対パスを `+` レジスタへヤンク
- `<leader>yg` / `<leader>yG` / `<leader>yo` で GitHub リンクのコピー・ブラウザ起動 (normal / visual 対応)

## Test plan
- [ ] `chezmoi apply` 後 `nvim` を起動し `:Lazy install` で gitlinker.nvim が入ること
- [ ] 任意ファイルを開き `<leader>yp` で相対パスがクリップボードへ入ること
- [ ] `<leader>yg` で HEAD commit SHA を含む GitHub URL がコピーされること
- [ ] `<leader>yG` で `main` を含む GitHub URL がコピーされること
- [ ] visual mode で範囲選択し `<leader>yg` を押すと `#L..-L..` 付き URL になること
- [ ] `<leader>yo` でブラウザが開くこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ファイルパスをクリップボードにコピーするキーマップを追加
  * GitHubリンクのコピーと、ブラウザで開く機能を追加
  * ノーマルモードとビジュアルモード両方で対応

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoh827/dotfiles/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->