### PR TITLE
feat: zshrc に端末固有 override 機構と dc/be alias を追加

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -252,7 +252,7 @@ export SLACK_WEBHOOK_URL="{{ onepasswordRead "op://Private/liiilwdlwpn5bsanstmra
 
 
 # machine-local overrides (not managed by chezmoi)
-[[ -f "$HOME/.zshrc.local" ]] && builtin source "$HOME/.zshrc.local"
+[[ -r "$HOME/.zshrc.local" ]] && builtin source "$HOME/.zshrc.local"
 
 # Fig post block. Keep at the bottom of this file.
 [[ -f "$HOME/.fig/shell/zshrc.post.zsh" ]] && builtin source "$HOME/.fig/shell/zshrc.post.zsh"# Created by `pipx` on 2025-06-21 14:21:17

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -120,6 +120,8 @@ alias b="brew"
 alias d="docker"
 alias c="claude"
 alias cds='cd $(chezmoi source-path)'
+alias dc='docker compose'
+alias be='bundle exec'
 
 # C で標準出力をクリップボードにコピーする
 # mollifier delta blog : http://mollifier.hatenablog.com/entry/20100317/p1
@@ -248,6 +250,9 @@ bindkey '^r' fzf-select-history
 export PATH="$PATH:$HOME/.local/bin"
 export SLACK_WEBHOOK_URL="{{ onepasswordRead "op://Private/liiilwdlwpn5bsanstmrarsozq/credential" }}"
 
+
+# machine-local overrides (not managed by chezmoi)
+[[ -f "$HOME/.zshrc.local" ]] && builtin source "$HOME/.zshrc.local"
 
 # Fig post block. Keep at the bottom of this file.
 [[ -f "$HOME/.fig/shell/zshrc.post.zsh" ]] && builtin source "$HOME/.fig/shell/zshrc.post.zsh"# Created by `pipx` on 2025-06-21 14:21:17


### PR DESCRIPTION
## Summary
- `~/.zshrc.local` が存在すれば source する hook を `dot_zshrc.tmpl` に追加。端末ごとの alias / 設定を chezmoi 管理外（このリポジトリにコミットしない形）で持てるようにする
- 全環境で使う頻度が高い 2-word コマンドを alias 化
  - `dc='docker compose'`
  - `be='bundle exec'`

## Motivation
- hanica の `bin/dev` を overmind 経由で起動する alias (`dev` / `dca`) を端末ごとに置きたいが、その手の hanica 固有設定は dotfiles リポジトリにコミットしたくない
- `~/.zshrc.local` を hook するだけで chezmoi の責務を汚さずに端末ローカル設定を分離できる

## Test plan
- [x] `chezmoi apply` 後 `~/.zshrc` の末尾に hook が入っていること
- [x] 新シェルで `alias dc be` が定義されていること
- [x] `~/.zshrc.local` を作成して alias を書くと、新シェル起動時に反映されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * よく使うコマンド用の新しいグローバルエイリアスを追加しました（`dc` と `be`）
  * ローカルマシン固有の設定上書きに対応しました。ホームディレクトリの設定ファイルが存在する場合、自動的に読み込まれるようになります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoh827/dotfiles/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->