### PR TITLE
feat: mise 用に MISE_GITHUB_TOKEN を 1Password から設定

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -249,6 +249,7 @@ bindkey '^r' fzf-select-history
 # exports
 export PATH="$PATH:$HOME/.local/bin"
 export SLACK_WEBHOOK_URL="{{ onepasswordRead "op://Private/liiilwdlwpn5bsanstmrarsozq/credential" }}"
+export MISE_GITHUB_TOKEN="{{ onepasswordRead "op://Private/2d2mux7yhbx57vaklhudb4uv5e/token" }}"
 
 
 # machine-local overrides (not managed by chezmoi)


### PR DESCRIPTION
## Summary
- mise が GitHub API のレート制限を回避するための `MISE_GITHUB_TOKEN` を zshrc に追加
- 既存の `onepasswordRead` テンプレート方式に合わせ、1Password (`op://Private/.../token`) から取得（秘密情報をリポジトリ/プレーンファイルに残さない）

## Test plan
- `chezmoi execute-template < dot_zshrc.tmpl` で `MISE_GITHUB_TOKEN` が `ghp_...` トークンに展開されることを確認済み
- `chezmoi apply` 後、新しい shell で `echo $MISE_GITHUB_TOKEN` が設定されていることを確認

このPRはClaude Codeを活用して作成しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他の変更**
  * パスワード管理システムから GitHub トークン環境変数を自動取得する設定を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->