### PR TITLE
nvim: termguicolors有効化・補完/フォーマッタ追加・キーマップ整備

### DIFF
--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -18,6 +18,13 @@ local options = {
   hlsearch = true,
   foldmethod = "indent",
   foldlevel = 10,
+  termguicolors = true,
+  undofile = true,
+  signcolumn = "yes",
+  scrolloff = 8,
+  updatetime = 250,
+  splitright = true,
+  splitbelow = true,
 }
 
 for k, v in pairs(options) do
@@ -32,7 +39,6 @@ vim.g.markdown_recommended_style = 0
 require("config.autocmds")
 
 require("config.lazy")
--- vim.opt.termguicolors = true
 vim.cmd[[colorscheme dracula]]
 
 
@@ -41,4 +47,3 @@ package.path = home_dir .. '/.config/nvim/' .. package.path
 
 require("keymaps")
 require("lsps")
-

--- a/dot_config/nvim/keymaps.lua
+++ b/dot_config/nvim/keymaps.lua
@@ -13,6 +13,9 @@ vim.keymap.set('n', '<leader>fg', builtin.live_grep, { desc = 'Telescope live gr
 vim.keymap.set('n', '<leader>fb', builtin.buffers, { desc = 'Telescope buffers' })
 vim.keymap.set('n', '<leader>fh', builtin.help_tags, { desc = 'Telescope help tags' })
 vim.keymap.set('n', '<leader>fr', [[<cmd>lua require('telescope').extensions.recent_files.pick()<CR>]], {noremap = true, silent = true, desc = 'Telescope Recent Files'})
+vim.keymap.set('n', '<leader>fd', builtin.diagnostics, { desc = 'Telescope diagnostics' })
+vim.keymap.set('n', '<leader>fs', builtin.lsp_document_symbols, { desc = 'Telescope document symbols' })
+vim.keymap.set('n', 'gr', builtin.lsp_references, { desc = 'Telescope LSP references' })
 
 -- memolist
 vim.keymap.set('n', '<leader>mn', ":MemoNew<CR>", { desc = 'Memo new' })
@@ -34,9 +37,20 @@ vim.api.nvim_set_keymap('n', '<leader>bc', ':bnext<CR>:bd#<CR>', { noremap = tru
 vim.api.nvim_set_keymap('n', '<S-l>', ':bnext<CR>', { noremap = true, silent = true, desc='Next buffer' })
 vim.api.nvim_set_keymap('n', '<S-h>', ':bprevious<CR>', { noremap = true, silent = true, desc='Previous buffer' })
 
+-- dial.nvim (increment / decrement)
+local dial = require("dial.map")
+vim.keymap.set("n", "<C-a>", dial.inc_normal(), { noremap = true, desc = "Increment" })
+vim.keymap.set("n", "<C-x>", dial.dec_normal(), { noremap = true, desc = "Decrement" })
+vim.keymap.set("v", "<C-a>", dial.inc_visual(), { noremap = true, desc = "Increment" })
+vim.keymap.set("v", "<C-x>", dial.dec_visual(), { noremap = true, desc = "Decrement" })
+vim.keymap.set("v", "g<C-a>", dial.inc_gvisual(), { noremap = true, desc = "Increment (gradual)" })
+vim.keymap.set("v", "g<C-x>", dial.dec_gvisual(), { noremap = true, desc = "Decrement (gradual)" })
+
 vim.keymap.set('i', '<S-Tab>', '<C-d>', { noremap = true, silent = true })
 
-vim.api.nvim_set_keymap("n", "<leader>gf", ":lua vim.lsp.buf.format()<CR>", { noremap = true, silent = true, desc = "Format" })
+vim.keymap.set('n', '<leader>gf', function()
+  require('conform').format({ async = true, lsp_format = 'fallback' })
+end, { noremap = true, silent = true, desc = "Format (conform/LSP)" })
 vim.api.nvim_set_keymap('n', 'gd', '<cmd>lua vim.lsp.buf.definition()<CR>', { noremap = true, silent = true, desc = "Definition" })
 vim.api.nvim_set_keymap('n', 'K', '<cmd>lua vim.lsp.buf.hover()<CR>', { noremap = true, silent = true, desc = "Hover" })
 vim.api.nvim_set_keymap('n', 'gi', '<cmd>lua vim.lsp.buf.implementation()<CR>', { noremap = true, silent = true, desc = "Implementation" })
@@ -78,4 +92,3 @@ vim.keymap.set('n', 'gl', function() vim.diagnostic.open_float(nil, { focus = fa
 vim.keymap.set('n', '[d', function() vim.diagnostic.jump({ count = -1, float = true }) end, { noremap = true, silent = true, desc = "Previous diagnostic" })
 vim.keymap.set('n', ']d', function() vim.diagnostic.jump({ count = 1, float = true }) end, { noremap = true, silent = true, desc = "Next diagnostic" })
 vim.keymap.set('n', '<leader>dq', vim.diagnostic.setloclist, { noremap = true, silent = true, desc = "Diagnostics to loclist" })
-

--- a/dot_config/nvim/lsps.lua
+++ b/dot_config/nvim/lsps.lua
@@ -7,3 +7,8 @@ local lspconfig = require('lspconfig')
 require("mason").setup()
 require("mason-lspconfig").setup()
 
+-- Wire blink.cmp completion capabilities into all LSP servers.
+local ok, blink = pcall(require, 'blink.cmp')
+if ok then
+  vim.lsp.config('*', { capabilities = blink.get_lsp_capabilities() })
+end

--- a/dot_config/nvim/lua/plugins/completion.lua
+++ b/dot_config/nvim/lua/plugins/completion.lua
@@ -1,0 +1,21 @@
+return {
+  {
+    "saghen/blink.cmp",
+    version = "1.*",
+    event = "InsertEnter",
+    opts = {
+      keymap = { preset = "default" },
+      appearance = { nerd_font_variant = "mono" },
+      completion = {
+        documentation = { auto_show = true, auto_show_delay_ms = 200 },
+        menu = { auto_show = true },
+      },
+      signature = { enabled = true },
+      sources = {
+        default = { "lsp", "path", "snippets", "buffer" },
+      },
+      fuzzy = { implementation = "prefer_rust_with_warning" },
+    },
+    opts_extend = { "sources.default" },
+  },
+}

--- a/dot_config/nvim/lua/plugins/conform.lua
+++ b/dot_config/nvim/lua/plugins/conform.lua
@@ -1,0 +1,22 @@
+return {
+  {
+    "stevearc/conform.nvim",
+    event = { "BufReadPre", "BufNewFile" },
+    cmd = { "ConformInfo" },
+    opts = {
+      formatters_by_ft = {
+        lua = { "stylua" },
+        javascript = { "prettierd", "prettier", stop_after_first = true },
+        javascriptreact = { "prettierd", "prettier", stop_after_first = true },
+        typescript = { "prettierd", "prettier", stop_after_first = true },
+        typescriptreact = { "prettierd", "prettier", stop_after_first = true },
+        json = { "prettierd", "prettier", stop_after_first = true },
+        css = { "prettierd", "prettier", stop_after_first = true },
+        html = { "prettierd", "prettier", stop_after_first = true },
+        go = { "gofmt" },
+        python = { "ruff_format" },
+        ruby = { "rubocop" },
+      },
+    },
+  },
+}


### PR DESCRIPTION
## 概要

nvim 設定の安全かつ効果の高い改善をまとめたものです。既存のキーマップ/プラグイン構成は壊さず、追加と明確な修正に絞っています。

## 変更点

### 要修正(実害あり)
- **`termguicolors` を有効化** (`init.lua`)。無効のままだと dracula 等のカラースキームが正しい色で描画されない。
- **補完エンジン blink.cmp を追加** (`lua/plugins/completion.lua`)。これまで mason で LSP は入れていたが補完UIが無く copilot のゴーストテキストのみだった。`lsps.lua` で LSP の capabilities を blink に接続。
- **dial.nvim のキーマップを追加** (`keymaps.lua`)。インストール済みだが `<C-a>`/`<C-x>` 未割当で使えていなかった。

### 追加
- **conform.nvim** (`lua/plugins/conform.lua`)。prettier/gofmt/stylua/ruff 等を統合。`<leader>gf` を conform + LSP フォールバックに変更。
- **基本オプション**: `undofile`(永続undo)、`signcolumn=yes`、`scrolloff=8`、`updatetime=250`、`splitright/splitbelow`。
- **telescope LSP キーマップ**: `<leader>fd`(diagnostics)、`<leader>fs`(document symbols)、`gr`(references)。

## 未対応(別PR提案)
構成を変える/好みに依存するため本PRには含めていない:
- ファイラ重複(`nerdtree` と `oil.nvim`)の整理。
- ステータスライン重複(`vim-airline` と `bufferline.nvim`)。lualine への寄せ替え。
- カラースキーム3種(dracula/catppuccin/onedark)の整理(`onedark.load()` が無駄ロード)。
- `easymotion` → `flash.nvim` 置換。
- `autocmds.lua` の VimEnter 毎 `lazy.update()` 自動実行(起動遅延・破損リスク)。

## 注意
ローカルの実 nvim での起動確認は未実施です。マージ前に手元で `nvim` を起動し、補完・フォーマット・dial の動作確認をお願いします。

---
🤖 plana が作成

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * LSP補完機能を追加
  * コード整形機能を統合
  * Telecopeの診断・シンボル検索とLSP参照キーマップを追加
  * インクリメント/デクリメント操作キーを追加

* **Configuration**
  * テキストエディタの表示・動作設定を拡張
  * カラースキーム設定を追加
  * フォーマット機能をアップデート

<!-- end of auto-generated comment: release notes by coderabbit.ai -->