### PR TITLE
feat: zshrc に bun のパス設定と補完を取り込む

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -266,3 +266,10 @@ if [ -f "$HOME/google-cloud-sdk/completion.zsh.inc" ]; then . "$HOME/google-clou
 
 # Kiro CLI post block. Keep at the bottom of this file.
 [[ -f "${HOME}/Library/Application Support/kiro-cli/shell/zshrc.post.zsh" ]] && builtin source "${HOME}/Library/Application Support/kiro-cli/shell/zshrc.post.zsh"
+
+# bun completions
+[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
+
+# bun
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"


### PR DESCRIPTION
## 概要
ホームの `~/.zshrc` に bun インストーラが追記していた以下のブロックが chezmoi 管理外になっており、`chezmoi apply` すると消える差分になっていた。これを chezmoi ソース `dot_zshrc.tmpl` の末尾(Kiro ブロックの後)に取り込む。

```sh
# bun completions
[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"

# bun
export BUN_INSTALL="$HOME/.bun"
export PATH="$BUN_INSTALL/bin:$PATH"
```

## 補足
- ホーム側でハードコードされていた `/Users/ryoh827/.bun/_bun` は、リポジトリの他記述に合わせて `$HOME/.bun/_bun` に正規化した(機能的には等価)。
- `chezmoi apply ~/.zshrc` でホーム側の表記も正規化され差分が 0 になる。

このPRはClaude Codeを活用して作成しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * zsh 起動時に bun を使えるようになりました。
  * `$HOME/.bun/_bun` がある場合、補完が自動で読み込まれます。
  * `BUN_INSTALL` を設定し、bun の `bin` を `PATH` の先頭に追加します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->