### PR TITLE
fix: cmu で apply 前に main へ切り替える

### DIFF
--- a/bin/executable_cmu
+++ b/bin/executable_cmu
@@ -1,3 +1,3 @@
 #!/bin/sh
 cd "$(chezmoi source-path)" || exit 1
-git pull && chezmoi apply
+git checkout main && git pull && chezmoi apply


### PR DESCRIPTION
## 概要
`cmu` コマンドが期待通り main を反映しない問題を修正します。

## 背景 / 問題
`cmu` は `chezmoi source-path`（`/Users/ryoh827/.local/share/chezmoi`）で `git pull && chezmoi apply` を実行しますが、ソースリポジトリが feature ブランチ（例: `zshrc-bun-block`）に残っていると、現在のブランチを pull/apply するだけで main の内容が反映されません。

## 変更点
`git pull` の前に `git checkout main` を実行し、常に main を取り込んでから `chezmoi apply` するようにしました。

```sh
git checkout main && git pull && chezmoi apply
```

このPRはClaude Codeを活用して作成しました