### PR TITLE
feat: デフォルトモデルを Fable 5 に変更

### DIFF
--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -12,7 +12,7 @@
   "permissions": {
     "defaultMode": "auto"
   },
-  "model": "fable",
+  "model": "claude-fable-5[1m]",
   "statusLine": {
     "type": "command",
     "command": "jq -r '\"💰 $\\(.cost.total_cost_usd // 0) | \\(.context_window.used_percentage // 0)% context used\"'"

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -12,7 +12,7 @@
   "permissions": {
     "defaultMode": "auto"
   },
-  "model": "sonnet",
+  "model": "fable",
   "statusLine": {
     "type": "command",
     "command": "jq -r '\"💰 $\\(.cost.total_cost_usd // 0) | \\(.context_window.used_percentage // 0)% context used\"'"


### PR DESCRIPTION
## Summary
- Claude Code の既定モデル設定を `sonnet` から `fable` (Fable 5) に変更

## Test plan
- [ ] `dot_claude/settings.json` の `model` が `"fable"` になっていることを確認
- [ ] chezmoi apply 後、新規セッションで `/model` を実行し Fable 5 が選択されていることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * AI の既定設定が更新され、応答に使われるモデルが切り替わりました。これにより、出力の品質や傾向が変わる場合があります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->