### PR TITLE
feat: git worktree 操作用のシェル関数を追加

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -238,6 +238,62 @@ function git-branch-switch() {
 }
 alias br='git-branch-switch'
 
+function git-worktree-switch() {
+  if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+    echo "Not inside a Git repository."
+    return 1
+  fi
+  local wt=$(git worktree list | fzf --header 'switch worktree' | awk '{print $1}')
+  [[ -n $wt ]] && cd "$wt"
+}
+alias gw='git-worktree-switch'
+
+function git-worktree-new() {
+  if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+    echo "Not inside a Git repository."
+    return 1
+  fi
+  local branch=$(git branch -a --format='%(refname:short)' | sed 's#^origin/##' | sort -u | fzf --header 'branch (未一致なら新規作成)' --print-query | tail -1)
+  [[ -z $branch ]] && return
+
+  # git-common-dir はどの worktree から実行しても本体リポジトリを指すので、
+  # worktree の中から実行しても命名が本体基準でぶれない
+  local common_dir=$(git rev-parse --git-common-dir)
+  [[ "$common_dir" != /* ]] && common_dir="$(pwd)/$common_dir"
+  local repo_root=$(dirname "$common_dir")
+  local dir="${repo_root}-${branch//\//-}"
+
+  if git show-ref --verify --quiet "refs/heads/${branch}"; then
+    git worktree add "$dir" "$branch"
+  else
+    git worktree add -b "$branch" "$dir"
+  fi
+  cd "$dir"
+}
+alias gwn='git-worktree-new'
+
+function git-worktree-remove() {
+  if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+    echo "Not inside a Git repository."
+    return 1
+  fi
+  local main_dir=$(git worktree list | head -1 | awk '{print $1}')
+  local current_dir=$(pwd)
+  local wts=$(git worktree list | tail -n +2 | grep -v '(bare)' | fzf -m --header 'remove worktree(s)' | awk '{print $1}')
+  [[ -z $wts ]] && return
+
+  local removed_current=0
+  local w
+  for w in ${(f)wts}; do
+    [[ "$w" == "$current_dir" ]] && removed_current=1
+    git worktree remove "$w" && echo "removed: $w"
+  done
+
+  # 今いた worktree を消した場合は本体リポジトリに戻る
+  [[ $removed_current -eq 1 ]] && cd "$main_dir"
+}
+alias gwrm='git-worktree-remove'
+
 function fzf-select-history() {
   BUFFER=$(history -n -r 1 | fzf --no-sort --query "$LBUFFER" --reverse)
   CURSOR=$#BUFFER

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -243,7 +243,7 @@ function git-worktree-switch() {
     echo "Not inside a Git repository."
     return 1
   fi
-  local wt=$(git worktree list | fzf --header 'switch worktree' | awk '{print $1}')
+  local wt=$(git worktree list --porcelain | awk '/^worktree /{print substr($0, 10)}' | fzf --header 'switch worktree')
   [[ -n $wt ]] && cd "$wt"
 }
 alias gw='git-worktree-switch'
@@ -253,7 +253,7 @@ function git-worktree-new() {
     echo "Not inside a Git repository."
     return 1
   fi
-  local branch=$(git branch -a --format='%(refname:short)' | sed 's#^origin/##' | sort -u | fzf --header 'branch (未一致なら新規作成)' --print-query | tail -1)
+  local branch=$(git branch -a --format='%(refname:short)' | grep -v '/HEAD$' | sed 's#^origin/##' | sort -u | fzf --header 'branch (未一致なら新規作成)' --print-query | tail -1)
   [[ -z $branch ]] && return
 
   # git-common-dir はどの worktree から実行しても本体リポジトリを指すので、
@@ -264,9 +264,11 @@ function git-worktree-new() {
   local dir="${repo_root}-${branch//\//-}"
 
   if git show-ref --verify --quiet "refs/heads/${branch}"; then
-    git worktree add "$dir" "$branch"
+    git worktree add "$dir" "$branch" || return 1
+  elif git show-ref --verify --quiet "refs/remotes/origin/${branch}"; then
+    git worktree add --track -b "$branch" "$dir" "origin/${branch}" || return 1
   else
-    git worktree add -b "$branch" "$dir"
+    git worktree add -b "$branch" "$dir" || return 1
   fi
   cd "$dir"
 }
@@ -277,19 +279,23 @@ function git-worktree-remove() {
     echo "Not inside a Git repository."
     return 1
   fi
-  local main_dir=$(git worktree list | head -1 | awk '{print $1}')
+  local main_dir=$(git worktree list --porcelain | awk '/^worktree /{print substr($0, 10); exit}')
   local current_dir=$(pwd)
-  local wts=$(git worktree list | tail -n +2 | grep -v '(bare)' | fzf -m --header 'remove worktree(s)' | awk '{print $1}')
+  local wts=$(git worktree list --porcelain | awk '/^worktree /{print substr($0, 10)}' | tail -n +2 | fzf -m --header 'remove worktree(s)')
   [[ -z $wts ]] && return
 
   local removed_current=0
   local w
   for w in ${(f)wts}; do
-    [[ "$w" == "$current_dir" ]] && removed_current=1
-    git worktree remove "$w" && echo "removed: $w"
+    if git worktree remove "$w"; then
+      echo "removed: $w"
+      [[ "$current_dir" == "$w" || "$current_dir" == "$w"/* ]] && removed_current=1
+    else
+      echo "failed to remove: $w" >&2
+    fi
   done
 
-  # 今いた worktree を消した場合は本体リポジトリに戻る
+  # 今いた worktree を削除できた場合のみ本体リポジトリに戻る
   [[ $removed_current -eq 1 ]] && cd "$main_dir"
 }
 alias gwrm='git-worktree-remove'


### PR DESCRIPTION
## Summary
- worktree の切り替え(`gw`)・新規作成(`gwn`)・削除(`gwrm`)を fzf ベースで行う関数を `dot_zshrc.tmpl` に追加
- 既存の `git-branch-switch` (`br`) と同じスタイル(関数 + alias、fzf UI)に統一
- `gwrm` は現在いる worktree を削除した場合に本体リポジトリへ自動で `cd` する
- `git worktree remove` の安全機構により、未コミット/未追跡ファイルが残る worktree は削除自体が拒否される(--force は付けていない)

## Test plan
- [x] `zsh -n` で追加した関数ブロックの構文チェック
- [x] 一時リポジトリで `git worktree remove` の挙動(untracked/dirty/clean)を検証し、意図通り安全側に倒れることを確認
- [ ] `chezmoi apply` 後に `gw` / `gwn` / `gwrm` を実際のシェルで動作確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Git worktree を扱う新しいコマンドと短縮 alias を追加しました。
  * worktree の切り替え、既存ブランチからの新規 worktree 作成、worktree の削除をより簡単に実行できるようになりました。
  * Git リポジトリ外ではエラーメッセージを表示して処理を中断するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->