### PR TITLE
fix: バッファ移動をbufferlineの表示順に合わせる

### DIFF
--- a/dot_config/nvim/keymaps.lua
+++ b/dot_config/nvim/keymaps.lua
@@ -34,13 +34,13 @@ vim.keymap.set('n', '<leader>mT', function()
     require('treesj').toggle({ split = { recursive = true } })
 end, { desc = 'Toggle tree (recursive)' })
 
--- buffer
+-- buffer (bufferline の表示順で移動する)
 vim.api.nvim_set_keymap('n', '<leader>bd', ':bd<CR>', { noremap = true, silent = true, desc='Delete buffer' })
-vim.api.nvim_set_keymap('n', '<leader>bn', ':bnext<CR>', { noremap = true, silent = true, desc='Next buffer' })
-vim.api.nvim_set_keymap('n', '<leader>bp', ':bprevious<CR>', { noremap = true, silent = true, desc='Previous buffer' })
+vim.api.nvim_set_keymap('n', '<leader>bn', '<cmd>BufferLineCycleNext<CR>', { noremap = true, silent = true, desc='Next buffer' })
+vim.api.nvim_set_keymap('n', '<leader>bp', '<cmd>BufferLineCyclePrev<CR>', { noremap = true, silent = true, desc='Previous buffer' })
 vim.api.nvim_set_keymap('n', '<leader>bc', ':bnext<CR>:bd#<CR>', { noremap = true, silent = true, desc='Close buffer' })
-vim.api.nvim_set_keymap('n', '<S-l>', ':bnext<CR>', { noremap = true, silent = true, desc='Next buffer' })
-vim.api.nvim_set_keymap('n', '<S-h>', ':bprevious<CR>', { noremap = true, silent = true, desc='Previous buffer' })
+vim.api.nvim_set_keymap('n', '<S-l>', '<cmd>BufferLineCycleNext<CR>', { noremap = true, silent = true, desc='Next buffer' })
+vim.api.nvim_set_keymap('n', '<S-h>', '<cmd>BufferLineCyclePrev<CR>', { noremap = true, silent = true, desc='Previous buffer' })
 
 -- dial.nvim (increment / decrement)
 local dial = require("dial.map")


### PR DESCRIPTION
## Summary
- bufferline.nvim は導入済みだが `<S-l>`/`<S-h>` と `<leader>bn`/`<leader>bp` が素の `:bnext`/`:bprevious`(バッファ番号順)のままで、表示上のタブ並び順と移動方向がずれていた
- `BufferLineCycleNext`/`BufferLineCyclePrev` に切り替え、bufferline の表示順で移動するように修正

## Test plan
- [ ] nvim を再起動し、複数バッファを開いた状態で `<S-l>`/`<S-h>` を押し、bufferline のタブ表示順通りに移動することを確認
- [ ] `<leader>bn`/`<leader>bp` でも同様に動作することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * バッファ切り替えの挙動を更新し、表示順に沿って次/前のバッファへ移動できるようになりました。
  * `leader` キーや `Shift + h/l` による移動操作が、より一貫したバッファ一覧ベースの切り替えになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->