### PR TITLE
feat: ターミナルモードで<C-w>を窓コマンドのプレフィクス化

### DIFF
--- a/dot_config/nvim/keymaps.lua
+++ b/dot_config/nvim/keymaps.lua
@@ -99,3 +99,5 @@ vim.keymap.set('n', 'gl', function() vim.diagnostic.open_float(nil, { focus = fa
 vim.keymap.set('n', '[d', function() vim.diagnostic.jump({ count = -1, float = true }) end, { noremap = true, silent = true, desc = "Previous diagnostic" })
 vim.keymap.set('n', ']d', function() vim.diagnostic.jump({ count = 1, float = true }) end, { noremap = true, silent = true, desc = "Next diagnostic" })
 vim.keymap.set('n', '<leader>dq', vim.diagnostic.setloclist, { noremap = true, silent = true, desc = "Diagnostics to loclist" })
+
+vim.keymap.set('t', '<C-w>', [[<C-\><C-n><C-w>]], { noremap = true, silent = true, desc = "Terminal: window command prefix" })


### PR DESCRIPTION
## Summary
- claudecode.nvim などのターミナルバッファで、ターミナルモード中の `<C-w>` を窓コマンドのプレフィクスに割り当て
- `<C-w>h` / `<C-w>p` などでターミナルを閉じずにエディタへフォーカス移動できる

## Test plan
- `:luafile ~/.config/nvim/keymaps.lua` もしくは Neovim 再起動
- `<leader>ac` で Claude を開き、入力中に `<C-w>h` でエディタ側へ移動できることを確認
- Claude パネルが閉じずに残っていることを確認

備考: 副作用としてターミナル内の `<C-w>`（単語削除）は無効になります。