### PR TITLE
chore: .claudeのローカル設定とworktreesをgitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
## Summary
- `.claude/settings.local.json` と `.claude/worktrees/` を `.gitignore` に追加
- Claude Code のローカル設定やworktree残骸が `git status` に出ないようにする

## Test plan
- `git status` に `.claude/` 配下が表示されないことを確認
- `git check-ignore -v .claude/worktrees/ .claude/settings.local.json` で無視対象になっていることを確認