### PR TITLE
feat: which-keyを画面中央のフロート表示にする

### DIFF
--- a/dot_config/nvim/lua/plugins/spec.lua
+++ b/dot_config/nvim/lua/plugins/spec.lua
@@ -73,6 +73,15 @@ return {
    "folke/which-key.nvim",
     event = "VeryLazy",
     opts = {
+      win = {
+        col = 0.5,
+        row = 0.5,
+        width = 0.6,
+        height = { min = 4, max = 25 },
+        border = "rounded",
+        title = true,
+        title_pos = "center",
+      },
       spec = {
         { "<leader>a", group = "AI/Claude" },
         { "<leader>b", group = "Buffer" },


### PR DESCRIPTION
## Summary
- which-key のポップアップを画面下部から中央のフロート表示へ変更
- `win` に `col=0.5`/`row=0.5`/`width=0.6`/rounded border/中央タイトルを設定

## Test plan
- [x] `chezmoi apply` 後、which-key がエラーなくロードし `win.col=0.5` が反映されることを headless で確認
- [ ] nvim で `<Space>` を押し、画面中央にフロートで候補が表示されることを目視確認