### PR TITLE
chore: mise/zshrcの実環境の変更を取り込む

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -1,9 +1,8 @@
 [tools]
 deno = "2.1.6"
 go = "1.23.4"
-ruby = ["3.5-dev", "3.4.4"]
+ruby = "3.4.4"
 rust = "stable"
-ghc = "9.12.2"
 node = "24.1.0"
 terraform = "latest"
 
@@ -15,3 +14,4 @@ venv_stdlib = true
 
 [settings.ruby]
 compile = false
+

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -31,3 +31,5 @@ if [ -f "$HOME/google-cloud-sdk/completion.zsh.inc" ]; then . "$HOME/google-clou
 # bun
 export BUN_INSTALL="$HOME/.bun"
 export PATH="$BUN_INSTALL/bin:$PATH"
+
+[[ "$TERM_PROGRAM" == "kiro" ]] && . "$(kiro --locate-shell-integration-path zsh)"


### PR DESCRIPTION
## Summary
- 実環境の `~/.config/mise/config.toml` を取り込み（`ruby` を `3.4.4` のみに、`ghc` を削除）
- 実環境の `~/.zshrc` の kiro シェル統合行を `dot_zshrc.tmpl` に取り込み

## Test plan
- `chezmoi diff ~/.config/mise/config.toml` で差分が出ないことを確認
- `chezmoi diff ~/.zshrc` で差分が出ないことを確認