### PR TITLE
feat: 端末周りをCatppuccin Latteベースのlightテーマに統一

### DIFF
--- a/dot_config/bat/config
+++ b/dot_config/bat/config
@@ -1,2 +1,2 @@
---theme="OneHalfDark"
+--theme="OneHalfLight"
 

--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -1,3 +1,3 @@
-theme = Catppuccin Mocha
+theme = Catppuccin Latte
 font-family = HackGen Console NF
 font-size = 15

--- a/dot_config/nvim/lua/plugins/spec.lua
+++ b/dot_config/nvim/lua/plugins/spec.lua
@@ -234,7 +234,7 @@ return {
         require('Comment').setup()
     end
   },
-  { "catppuccin/nvim", name = "catppuccin", priority = 1000 },
+  { "catppuccin/nvim", name = "catppuccin", priority = 1000, opts = { flavour = "latte" } },
   {
     "iamcco/markdown-preview.nvim",
     cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -13,7 +13,7 @@
 
 [delta]
   navigate     = true
-  dark         = true
+  light        = true
   algorithm    = histogram
   submodule    = log
   side-by-side = false


### PR DESCRIPTION
## Summary
- ghostty のテーマを Catppuccin Mocha から Catppuccin Latte に変更
- ダーク前提だった delta (`light = true`) と bat (`OneHalfLight`) を light 向けに切り替え
- nvim の catppuccin flavour を latte に設定

## Test plan
- `chezmoi apply` 後、ghostty をリロードして背景が light になることを確認
- `git diff` で delta が light 配色になることを確認
- `bat <file>` が OneHalfLight で表示されることを確認
- nvim を再起動して catppuccin latte になることを確認