### PR TITLE
feat: nvimでClaude編集ファイルをBufEnter時に自動リロード

### DIFF
--- a/dot_config/nvim/lua/config/autocmds.lua
+++ b/dot_config/nvim/lua/config/autocmds.lua
@@ -23,11 +23,18 @@ vim.api.nvim_create_autocmd("BufReadPost", {
 })
 
 vim.o.autoread = true
-vim.api.nvim_create_autocmd({ "FocusGained", "TermClose", "TermLeave" }, {
+vim.api.nvim_create_autocmd({ "FocusGained", "BufEnter", "TermClose", "TermLeave" }, {
   group = augroup,
   callback = function()
     if vim.o.buftype ~= "nofile" then
       vim.cmd("checktime")
     end
+  end,
+})
+
+vim.api.nvim_create_autocmd("FileChangedShellPost", {
+  group = augroup,
+  callback = function()
+    vim.notify("File reloaded from disk", vim.log.levels.INFO, { title = "autoread" })
   end,
 })


### PR DESCRIPTION
## Summary
- `checktime` の発火イベントに `BufEnter` を追加し、Claude Code がディスク上で編集したファイルへ直接切り替えた際も自動リロードされるようにした
- `FileChangedShellPost` でリロード時に通知を表示するようにした

## Test plan
- nvim でファイルを開いた状態で外部からそのファイルを編集し、別バッファへ移動→当該バッファへ `BufEnter` した際に内容が更新され通知が出ることを確認