### PR TITLE
feat: nvim補完の確定キーをsuper-tabプリセットに変更

### DIFF
--- a/dot_config/nvim/lua/plugins/completion.lua
+++ b/dot_config/nvim/lua/plugins/completion.lua
@@ -4,7 +4,7 @@ return {
     version = "1.*",
     event = "InsertEnter",
     opts = {
-      keymap = { preset = "default" },
+      keymap = { preset = "super-tab" },
       appearance = { nerd_font_variant = "mono" },
       completion = {
         documentation = { auto_show = true, auto_show_delay_ms = 200 },


### PR DESCRIPTION
## Summary
- blink.cmpのkeymapを`default`から`super-tab`プリセットへ変更
- Tabで先頭候補を確定できるようにした（Enterは通常の改行のまま）

## Test plan
- `chezmoi apply ~/.config/nvim/lua/plugins/completion.lua`
- nvimを再起動し、挿入モードで補完が出た状態でTabを押すと先頭候補が確定されることを確認