### PR TITLE
fix: change claudecode diff layout to horizontal

### DIFF
--- a/dot_config/nvim/lua/plugins/spec.lua
+++ b/dot_config/nvim/lua/plugins/spec.lua
@@ -292,7 +292,7 @@ return {
         split_width_percentage = 0.5,
       },
       diff_opts = {
-        layout = "vertical",
+        layout = "horizontal",
       },
     },
     cmd = {


### PR DESCRIPTION
claudecode.nvim のdiffが左右分割（横並び）で開いていたため、上下分割に変更。

- `layout = "vertical"` はVim用語で縦の分割線＝左右並びになるため `horizontal` に修正