### PR TITLE
fix: forward extended keys through tmux for shift+enter support

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -27,4 +27,8 @@ setw -g pane-base-index 1
 set -g default-terminal "tmux-256color"
 set -ga terminal-overrides ",xterm-ghostty:Tc"
 
+# forward shift+enter etc. (kitty keyboard protocol) to apps like Claude Code
+set -g extended-keys always
+set -as terminal-features 'xterm-ghostty:extkeys'
+
 set -g history-limit 10000


### PR DESCRIPTION
## Summary
- tmux introduction broke Shift+Enter (newline) in Claude Code because tmux only forwards kitty keyboard protocol sequences to panes that explicitly request them
- Add `extended-keys always` and `terminal-features 'xterm-ghostty:extkeys'` so Ghostty's extended key sequences are unconditionally passed through to apps like Claude Code

## Test plan
- [ ] `chezmoi apply` then `tmux source-file ~/.tmux.conf` (or restart tmux session)
- [ ] Confirm Shift+Enter inserts a newline in Claude Code inside a tmux pane