### PR TITLE
fix: shrink fugitive git status window via previewheight

### DIFF
--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -26,6 +26,7 @@ local options = {
   updatetime = 250,
   splitright = true,
   splitbelow = true,
+  previewheight = 15,
 }
 
 for k, v in pairs(options) do

--- a/dot_config/nvim/lua/plugins/spec.lua
+++ b/dot_config/nvim/lua/plugins/spec.lua
@@ -184,7 +184,7 @@ return {
     "tpope/vim-fugitive",
     cmd = { "Git", "Gdiffsplit", "Gvdiffsplit" },
     keys = {
-      { "<leader>gs", "<cmd>Git<cr>", desc = "Git status" },
+      { "<leader>gs", "<cmd>Git!<cr>", desc = "Git status" },
       { "<leader>gd", "<cmd>Gvdiffsplit<cr>", desc = "Git diff (vsplit)" },
       { "<leader>gw", "<cmd>Gwrite<cr>", desc = "Git stage current file" },
       { "<leader>gu", "<cmd>Git restore --staged %<cr>", desc = "Git unstage current file" },


### PR DESCRIPTION
## Summary
- `:Git` (bare) opens a `keepalt split` at half the window height by default
- Switch `<leader>gs` to `:Git!`, which routes through fugitive's `pedit` branch and sizes the status window via `previewheight`
- Set `previewheight = 15` in init.lua

## Test plan
- [ ] `nvim`, run `<leader>gs`, confirm the git status window opens at ~15 lines instead of half the screen