### PR TITLE
feat: dynamic exclude globs for telescope live grep

### DIFF
--- a/dot_config/nvim/lua/config/keymaps.lua
+++ b/dot_config/nvim/lua/config/keymaps.lua
@@ -11,7 +11,9 @@ vim.keymap.set('n', '<Esc>', '<cmd>nohlsearch<CR>', { silent = true, desc = 'Cle
 -- Telescope
 local builtin = require('telescope.builtin')
 vim.keymap.set('n', '<leader>ff', builtin.find_files, { desc = 'Telescope find files' })
-vim.keymap.set('n', '<leader>fg', builtin.live_grep, { desc = 'Telescope live grep' })
+vim.keymap.set('n', '<leader>fg', function()
+  require('telescope').extensions.live_grep_args.live_grep_args()
+end, { desc = 'Telescope live grep (args)' })
 vim.keymap.set('n', '<leader>fb', builtin.buffers, { desc = 'Telescope buffers' })
 vim.keymap.set('n', '<leader>fh', builtin.help_tags, { desc = 'Telescope help tags' })
 vim.keymap.set('n', '<leader>fr', [[<cmd>lua require('telescope').extensions.recent_files.pick()<CR>]], {noremap = true, silent = true, desc = 'Telescope Recent Files'})

--- a/dot_config/nvim/lua/plugins/telescope.lua
+++ b/dot_config/nvim/lua/plugins/telescope.lua
@@ -5,6 +5,7 @@ return {
       'nvim-lua/plenary.nvim',
       'nvim-telescope/telescope-ui-select.nvim',
       { 'nvim-telescope/telescope-fzf-native.nvim', build = 'make' },
+      { 'nvim-telescope/telescope-live-grep-args.nvim', version = '^1.0.0' },
     },
     config = function()
       require('telescope').setup({
@@ -28,6 +29,7 @@ return {
       })
       require('telescope').load_extension('ui-select')
       require('telescope').load_extension('fzf')
+      require('telescope').load_extension('live_grep_args')
     end,
   },
   {


### PR DESCRIPTION
## Summary
- Add `nvim-telescope/telescope-live-grep-args.nvim` so rg flags typed in the live_grep prompt (e.g. `-g !spec/**`) are actually parsed and applied
- Rewire `<leader>fg` to use `extensions.live_grep_args.live_grep_args()` instead of vanilla `builtin.live_grep`

## Test plan
- [ ] `:Lazy sync` to install the new plugin
- [ ] `<leader>fg`, type `searchterm -g !spec/**`, confirm matches under `spec/` are excluded
- [ ] `<leader>fg` with a plain search term still works as before