### PR TITLE
feat: switch nvim and ghostty theme to rose-pine-dawn

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -1,3 +1,3 @@
-theme = Catppuccin Latte
+theme = Rose Pine Dawn
 font-family = HackGen Console NF
 font-size = 15

--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -39,7 +39,7 @@ vim.g.copilot_filetypes = {
 vim.g.markdown_recommended_style = 0
 
 require("config.lazy")
-vim.cmd[[colorscheme catppuccin]]
+vim.cmd[[colorscheme rose-pine-dawn]]
 
 require("config.keymaps")
 require("config.lsps")

--- a/dot_config/nvim/lua/plugins/spec.lua
+++ b/dot_config/nvim/lua/plugins/spec.lua
@@ -31,7 +31,7 @@ return {
     config = function()
       require("lualine").setup({
         options = {
-          theme = "catppuccin",
+          theme = "rose-pine",
         },
       })
     end,
@@ -245,7 +245,7 @@ return {
         require('Comment').setup()
     end
   },
-  { "catppuccin/nvim", name = "catppuccin", priority = 1000, opts = { flavour = "latte" } },
+  { "rose-pine/neovim", name = "rose-pine", priority = 1000, opts = { variant = "dawn" } },
   {
     "iamcco/markdown-preview.nvim",
     cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },


### PR DESCRIPTION
## Summary
- Switch nvim colorscheme, lualine theme, and ghostty theme from Catppuccin Latte to rose-pine-dawn
- Motivated by low contrast in Latte: comments measured 2.30:1 against the `#eff1f5` background, well under the 4.5:1 readability guideline

## Measured contrast (rose-pine-dawn, from actual runtime highlight groups)
| Group | Color | Ratio |
|---|---|---|
| `@variable` | `#464261` | 8.69:1 |
| `Keyword` | `#286983` | 5.59:1 |
| `Comment` | `#797593` | 4.02:1 (was 2.30:1) |
| `DiagnosticError` | `#b4637a` | 3.84:1 |
| `Type` | `#56949f` | 3.14:1 |
| `LineNr` | `#9893a5` | 2.73:1 |
| `Function` | `#d7827e` | 2.60:1 |
| `String` / `DiagnosticWarn` | `#ea9d34` | 2.05:1 |

Comments improve as intended. `String`, `Function`, and `LineNr` remain below 3:1 and can be overridden via `highlight_groups` later if they prove hard to read in practice.

## Test plan
- `chezmoi apply` succeeds for the three changed files
- `nvim --headless` reports `colors_name=rose-pine`, `Normal` bg `#faf4ed`, and `lualine` theme `rose-pine`
- rose-pine ships `lua/lualine/themes/rose-pine.lua`, so the lualine theme name resolves
- `ghostty +list-themes` includes `Rose Pine Dawn`