### PR TITLE
feat: switch nvim and ghostty theme to rose-pine moon variant

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -1,3 +1,3 @@
-theme = Rose Pine Dawn
+theme = Rose Pine Moon
 font-family = HackGen Console NF
 font-size = 15

--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -39,7 +39,7 @@ vim.g.copilot_filetypes = {
 vim.g.markdown_recommended_style = 0
 
 require("config.lazy")
-vim.cmd[[colorscheme rose-pine-dawn]]
+vim.cmd[[colorscheme rose-pine-moon]]
 
 require("config.keymaps")
 require("config.lsps")

--- a/dot_config/nvim/lua/plugins/spec.lua
+++ b/dot_config/nvim/lua/plugins/spec.lua
@@ -245,7 +245,7 @@ return {
         require('Comment').setup()
     end
   },
-  { "rose-pine/neovim", name = "rose-pine", priority = 1000, opts = { variant = "dawn" } },
+  { "rose-pine/neovim", name = "rose-pine", priority = 1000, opts = { variant = "moon" } },
   {
     "iamcco/markdown-preview.nvim",
     cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },


### PR DESCRIPTION
## Summary
- Switch from `rose-pine-dawn` (light) to `rose-pine-moon` (dark) for nvim and ghostty, keeping the same hue family
- Follow-up to #87: the light variant left `String`, `Function`, and `LineNr` below 3:1, and the dark variant fixes exactly those

## Measured contrast (nvim highlight groups, actual runtime values)
| Group | dawn (#87) | moon (this PR) |
|---|---|---|
| `String` | 2.05:1 | **9.55:1** |
| `Type` | 3.14:1 | **9.19:1** |
| `Function` | 2.60:1 | **7.13:1** |
| `Comment` | 4.02:1 | **4.86:1** |
| `Keyword` | 5.59:1 | 4.29:1 |
| `LineNr` | 2.73:1 | **3.03:1** |
| AA (4.5:1) met | 1/6 | **4/6** |

The gold used for strings and warnings was the worst offender on the light background at 2.05:1. On `#232136` the same `#f6c177` measures 9.55:1.

## Why moon over main
`main` has a higher average (7.31 vs 6.34), but that is mostly an artifact of its darker background: `Comment`, `String`, and `Type` are the *same* hex in both variants, and `main`'s background luminance is 0.0095 against moon's 0.0171. The two variants genuinely differ only in `Keyword` and `Function`.

Excluding `LineNr`, which is intentionally de-emphasized, the worst content token is what drives perceived strain:

- `main`: `Keyword` `#31748f` — 3.38:1
- `moon`: `Keyword` `#3e8fb0` — **4.29:1**

`Keyword` is `main`'s weakest group and appears constantly in code, so moon's floor is the better trade. The same ordering holds for ghostty's ANSI palette (moon min 4.29 vs main min 3.38).

Background rationale for going dark at all: measuring ghostty's ANSI 1-6 across 4 light and 9 dark bundled themes, every light theme except GitHub Light Default scored worse than every dark theme. Legible accents on a light background have to be dark and desaturated, so light themes tend to trade contrast for appearance.

## Test plan
- `chezmoi apply` succeeds for the three changed files
- `nvim --headless` reports `Normal` bg `#232136`, `Comment` `#908caa`, `String` `#f6c177`, `Function` `#ea9a97`, `Keyword` `#3e8fb0`, `Type` `#9ccfd8`, `LineNr` `#6e6a86`, lualine theme `rose-pine`
- `ghostty +list-themes` includes `Rose Pine Moon`