### PR TITLE
feat: bump ghostty font-size to 16

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -1,3 +1,3 @@
 theme = Rose Pine Moon
 font-family = HackGen Console NF
-font-size = 15
+font-size = 16


### PR DESCRIPTION
## Summary
- Raise Ghostty `font-size` from 15 to 16.
- The external 27" WQHD panel runs at 1x, so one point is one physical pixel and a 15px full-width box left dense kanji hard to read.

## Test plan
- `ghostty +validate-config` passes.
- Reload with ⌘⇧, and confirm Japanese text renders legibly.